### PR TITLE
chore: bump version to 0.3.2 and upgrade pybind11 to 2.13.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ distributing this library.
 
 ## Changelog
 
+- **0.3.2** Upgraded pybind11 to support cmake 4.x compilation
 - **0.3.1** Using CGAL6
 - **0.3.0** Added `do_intersect`.
 - **0.2.0** Made the library more robust and added a `repair`-method as the

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # https://scikit-build.readthedocs.io/en/latest/usage.html#setup-options
     # https://github.com/d-krupke/skbuild-conan#usage
     name="pyvispoly",
-    version="0.3.1",
+    version="0.3.2",
     author="Dominik Krupke",
     license="LICENSE",
     description="CGAL's visibility polygons in Python",

--- a/src/pyvispoly/CMakeLists.txt
+++ b/src/pyvispoly/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Created by the script cgal_create_cmake_script This is the CMake script for
 # compiling a CGAL application.
-cpmaddpackage("gh:pybind/pybind11@2.10.0") # pybind11, essential
+cpmaddpackage("gh:pybind/pybind11@2.13.6") # pybind11, essential
 find_package(CGAL REQUIRED)
 find_package(fmt REQUIRED)
 


### PR DESCRIPTION
On macOS the build was failing because CMake 4.x is installed, but pybind11 v2.10.0’s CMakeLists.txt still has: `cmake_minimum_required(VERSION 3.4)`

Starting with CMake 4.x, using policies for versions below 3.5 requires an explicit flag. There are two ways to fix this:

1. In `setup.py`, add:
```
cmake_args=["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"],
```

2. Upgrade the pybind11 dependency to a newer version.

I’ve chosen the latter.